### PR TITLE
✨ feat: add path type for translation config

### DIFF
--- a/lib/contexts/ConfigContext/ConfigContext.tsx
+++ b/lib/contexts/ConfigContext/ConfigContext.tsx
@@ -1,12 +1,12 @@
 import { createContext, useContext } from 'react'
 
-import { ReadonlyConfig, Translator } from '../../defs'
+import { ReadonlyConfig, Translator, TranslatorPath } from '../../defs'
 
 type ConfigContextProps = {
   readonly?: ReadonlyConfig
   disableWarnings?: boolean
   isExpanded?: boolean
-  t: Translator
+  t: Translator | TranslatorPath
 }
 
 export const ConfigContext = createContext<ConfigContextProps>(

--- a/lib/contexts/ConfigContext/ConfigContextProvider.tsx
+++ b/lib/contexts/ConfigContext/ConfigContextProvider.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react'
 
-import { LanguageConfig, Path, ReadonlyConfig } from '../../defs'
+import { LanguageConfig, ReadonlyConfig, TranslatorPath } from '../../defs'
 import i18n from '../../i18n.json'
 import { t } from '../../utils/i18n'
 import { ConfigContext } from './ConfigContext'
@@ -24,12 +24,9 @@ export const ConfigContextProvider: React.FC<ConfigContextProviderProps> = ({
   config,
   children,
 }) => {
-  const translator = (path: string) => {
+  const translator: TranslatorPath = (path: string) => {
     if (config?.language?.translations) {
-      const translation: Path<typeof config.language.translations> | string = t(
-        path,
-        config.language.translations,
-      )
+      const translation = t(path, config.language.translations)
       if (translation !== path) return translation
     }
 

--- a/lib/defs.ts
+++ b/lib/defs.ts
@@ -88,6 +88,8 @@ export type ReadonlyConfig = boolean | RegExp[]
 
 export type Translator = (path: string) => string
 
+export type TranslatorPath = (path: Path<typeof i18n>) => string
+
 type DeepPartial<T> = T extends object
   ? {
       [P in keyof T]?: DeepPartial<T[P]>


### PR DESCRIPTION
Here how i added the type Path for the translation configuration, had an issue when i first added only the type.
Exemple :
```js
const translation: Path<typeof config.language.translations> = t(
        path,
        config.language.translations,
      )
```
doesn't work so i just added `Path<typeof config.language.translations> | string`!