### PR TITLE
🐛 fix: fix string validations

### DIFF
--- a/lib/LeafItToMe.stories.tsx
+++ b/lib/LeafItToMe.stories.tsx
@@ -11,6 +11,19 @@ const meta: Meta<typeof LeafItToMe> = {
     layout: 'centered',
   },
   tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          height: '100%',
+          width: '700px',
+          padding: '20px',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
 }
 
 export default meta

--- a/lib/components/Leaf/Leaf.stories.tsx
+++ b/lib/components/Leaf/Leaf.stories.tsx
@@ -16,11 +16,19 @@ const meta: Meta<typeof Leaf> = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <ConfigContextProvider>
-        <TreeContextProvider tree={{ type: 'null', path: '' }}>
-          <Story />
-        </TreeContextProvider>
-      </ConfigContextProvider>
+      <div
+        style={{
+          height: '100%',
+          width: '700px',
+          padding: '20px',
+        }}
+      >
+        <ConfigContextProvider>
+          <TreeContextProvider tree={{ type: 'null', path: '' }}>
+            <Story />
+          </TreeContextProvider>
+        </ConfigContextProvider>
+      </div>
     ),
   ],
 }

--- a/lib/utils/json.test.ts
+++ b/lib/utils/json.test.ts
@@ -8,7 +8,7 @@ import {
 } from './json'
 
 describe('isValidString', () => {
-  it('should be valid for keys without special characters', () => {
+  it('should be valid for strings without special characters', () => {
     expect(isValidString('key')).toBe(true)
     expect(isValidString('another_key')).toBe(true)
     expect(isValidString('another key')).toBe(true)
@@ -17,18 +17,20 @@ describe('isValidString', () => {
     expect(isValidString('unescaped / solidus')).toBe(true)
   })
 
-  it('should be valid for keys with escaped characters', () => {
+  it('should be valid for strings with escaped characters', () => {
     expect(isValidString(String.raw`escaped \n newline`)).toBe(true)
     expect(isValidString(String.raw`escaped \t tab`)).toBe(true)
-    expect(isValidString(String.raw`escaped \" quote`)).toBe(true)
-    expect(isValidString(String.raw`escaped \\ reverse solidus`)).toBe(true)
+    expect(isValidString(String.raw`escaped " quote`)).toBe(true)
+    expect(isValidString(String.raw`escaped \ reverse solidus`)).toBe(true)
     expect(isValidString(String.raw`unicode \u1234`)).toBe(true)
   })
 
-  it('should be invalid for keys with unescaped characters', () => {
-    expect(isValidString(String.raw`unescaped " quote`)).toBe(false)
-    expect(isValidString(String.raw`unescaped \ reverse solidus`)).toBe(false)
+  it('should be invalid for strings with unescaped characters', () => {
     expect(isValidString(String.raw`unterminatedKey \u12`)).toBe(false)
+  })
+
+  it('should be valid for strings with stringified json', () => {
+    expect(isValidString('{"a":"b"}'))
   })
 })
 
@@ -574,14 +576,6 @@ describe('getJsonDescription', () => {
   })
 
   it('should throw a SyntaxError for invalid string values', () => {
-    expect(() =>
-      getJsonDescription({ a: String.raw`unescaped " quote` }),
-    ).toThrowError('Invalid JSON value at path ""')
-
-    expect(() =>
-      getJsonDescription({ a: String.raw`unescaped \ reverse solidus` }),
-    ).toThrowError('Invalid JSON value at path ""')
-
     expect(() =>
       getJsonDescription({ a: String.raw`unterminatedKey \u12` }),
     ).toThrowError('Invalid JSON value at path ""')

--- a/lib/utils/json.ts
+++ b/lib/utils/json.ts
@@ -2,7 +2,7 @@ import { JSONType, LeafType, Node, Primitive } from '../defs'
 import { toKebabCase } from './string'
 
 export const isValidString = (key: string): boolean =>
-  /^(?:[^"\\]|\\["\\/bfnrt]|\\u[0-9a-fA-F]{4})*$/.test(key)
+  /^(?:[^\\]|\\[^u]|\\u[0-9a-fA-F]{4})*$/.test(key)
 
 export const isValidNumber = (input: string): boolean =>
   /^-{0,1}[0-9]+\.{0,1}[0-9]*([eE]{1}[+-]{1}[0-9]+){0,1}$/.test(input)
@@ -46,8 +46,9 @@ export const getJsonDescription = (
 
   // JSON strings are double quoted and must escape some chars
   // We check if the given string is valid according to those rules
-  if (typeof input === 'string' && !isValidString(input))
+  if (typeof input === 'string' && !isValidString(input)) {
     throw new SyntaxError(`Invalid JSON value at path "${path}".`)
+  }
 
   // The same rule exist for JSON keys
   if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leaf-it-to-me",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leaf-it-to-me",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.3",
         "@commitlint/cli": "^19.6.1",
@@ -32,6 +32,8 @@
         "globals": "^15.14.0",
         "husky": "^9.1.7",
         "prettier": "^3.4.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "storybook": "^8.4.7",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
@@ -4701,7 +4703,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4922,6 +4925,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -5378,6 +5382,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5434,6 +5439,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5643,6 +5649,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaf-it-to-me",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "main": "dist/leaf-it-to-me.js",
   "types": "dist/LeafItToMe.d.ts",


### PR DESCRIPTION
### Fix string validations

Previously was checking if special characters were escaped, which is actually a bad idea since it breaks strings.  
Escaping occur for language specific purposes, in binary, a string is a string even with JS special character inside.  
The only case left is unfinished unicode, since it can break a string.

#### Bonus

Fixed some stories templates after long text handling since we now need a predefined width in storybook "centered" stories.