### PR TITLE
Store expanded node state in TreeContextProvider

### DIFF
--- a/lib/components/TreeView.tsx
+++ b/lib/components/TreeView.tsx
@@ -4,7 +4,7 @@ import { useConfigContext } from '../contexts/ConfigContext/ConfigContext'
 import { useTreeContext } from '../contexts/TreeContext/TreeContext'
 import { LeafMode, Node, VariantState } from '../defs'
 import { classNames } from '../utils/classNames'
-import { isReadonly, shouldExpand } from '../utils/config'
+import { isReadonly } from '../utils/config'
 import { hashCode } from '../utils/memoization'
 import { ActionButton } from './ActionButton'
 import { Leaf } from './Leaf'
@@ -20,11 +20,8 @@ type TreeProps = {
 
 export const TreeView: React.FC<TreeProps> = memo(
   ({ node, mode }) => {
-    const { readonly, t, isExpanded: expandedConfig } = useConfigContext()
-    const { addNode, setEditing } = useTreeContext()
-    const [isExpanded, setIsExpanded] = useState<boolean>(
-      shouldExpand(expandedConfig, node.path),
-    )
+    const { readonly, t } = useConfigContext()
+    const { addNode, setEditing, isExpanded, setIsExpanded } = useTreeContext()
     const [addNodeError, setAddNodeError] = useState<string>('')
 
     return (
@@ -39,24 +36,24 @@ export const TreeView: React.FC<TreeProps> = memo(
             (!readonly || node.children?.length) ? (
               <ActionButton
                 className={classNames('button-toggle', {
-                  expanded: isExpanded,
+                  expanded: isExpanded(node.path),
                 })}
                 aria-label={t(
-                  `tree-view.action.toggle.label.${isExpanded ? 'close' : 'open'}`,
+                  `tree-view.action.toggle.label.${isExpanded(node.path) ? 'close' : 'open'}`,
                 )}
-                aria-expanded={isExpanded}
+                aria-expanded={isExpanded(node.path)}
                 icon={<Chevron />}
                 popover={{
                   content: t(
-                    `tree-view.action.toggle.label.${isExpanded ? 'close' : 'open'}`,
+                    `tree-view.action.toggle.label.${isExpanded(node.path) ? 'close' : 'open'}`,
                   ),
                 }}
-                onClick={() => setIsExpanded((prev) => !prev)}
+                onClick={() => setIsExpanded(node.path, !isExpanded(node.path))}
               />
             ) : null
           }
         />
-        {isExpanded && (
+        {isExpanded(node.path) && (
           <>
             {node.children?.map((child) => (
               <TreeView

--- a/lib/contexts/TreeContext/TreeContext.tsx
+++ b/lib/contexts/TreeContext/TreeContext.tsx
@@ -14,6 +14,8 @@ export type TreeContextProps = {
   deleteNode: DeleteNodeAction
   editing: string | null
   setEditing: Dispatch<SetStateAction<string | null>>
+  isExpanded: (path: string) => boolean
+  setIsExpanded: (path: string, expanded: boolean) => void
 }
 
 export const TreeContext = createContext<TreeContextProps>(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leaf-it-to-me",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaf-it-to-me",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "main": "dist/leaf-it-to-me.js",
   "types": "dist/LeafItToMe.d.ts",


### PR DESCRIPTION
Before this update, when a new leaf is added to a tree, it re-render the tree and the new leaf but keep all leafs expanded.
Now the expanded state is stored in the **TreeContextProvider**.